### PR TITLE
use ed25519 keys instead of rsa keys

### DIFF
--- a/content/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
+++ b/content/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent.md
@@ -19,7 +19,7 @@ If you don't want to reenter your passphrase every time you use your SSH key, yo
 {% data reusables.command_line.open_the_multi_os_terminal %}
 2. Paste the text below, substituting in your {% data variables.product.product_name %} email address.
   ```shell
-  $ ssh-keygen -t rsa -b 4096 -C "<em>your_email@example.com</em>"
+  $ ssh-keygen -t ed25519 -C "<em>your_email@example.com</em>"
   ```
   This creates a new ssh key, using the provided email as a label.
   ```shell


### PR DESCRIPTION
RSA keys are outdated. Even by using larger 4096 keys maybe it's best to move away from rsa keys altogether. 

This PR updates the document to suggest using ed25519 keys which, at this time, defaults to a 16 round key deviation function. It may be useful to suggest more rounds for the KDF but that's for a different PR. 

--timball

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [ ] All of the tests are passing.
- [ ] I have reviewed my changes in staging.
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [x] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
